### PR TITLE
Add the dependencies of the python script

### DIFF
--- a/native/installer.html
+++ b/native/installer.html
@@ -48,6 +48,8 @@
 
       <div class="small"><label>Python script:</label>
         <button type="submit" formaction="native.py" formmethod="get">Download</button></div>
+      
+      <p>Make sure that the dependencies for the script are installed. Among the needed packages is <code>wmctrl</code>. On Fedora this can be installed with <code>sudo dnf install wmctrl</code></p>
 
       <div><label>Installed location of Python script:</label>
         <input type="text" id="location" pattern="\/[^\0]*[^\/]"></input>


### PR DESCRIPTION
The manual instructions were missing a mention of dependencies without which the installation will fail silently.

fixes: #4 

I didn't test any of it because I don't build the extension... but the changes seem unintrusive just have an extra look and testbuild before merging.