### PR TITLE
Support Wayland-based desktop environments

### DIFF
--- a/native/native.py
+++ b/native/native.py
@@ -37,6 +37,10 @@ ffPid = int(subprocess.run(["bash", "-c", "wmctrl -lp | grep -Fh $(pgrep firefox
 
 import gi
 gi.require_version('Gdk', '3.0')
+
+import gi.module
+gi.module.get_introspection_module('Gdk').set_allowed_backends('x11')
+
 from gi.repository import Gdk, GdkX11
 
 gdk_display = GdkX11.X11Display.get_default()


### PR DESCRIPTION
Firefox doesn't support Wayland yet, but GDK prefers Wayland to X11
when both environments are available. To keep the extension usable on
Wayland environments, we have to force GDK to choose the X11 backend.

There is a function in C API of GDK called gdk_set_allowed_backends,
which can be used to modify the priority of GDK backends. It must be
called before opening a display. However, the usual way to import GDK
in python, 'from gi.repository import Gdk', runs override scripts which
automatically calls gdk_init_check.

Therefore, we use 'gi.module.get_introspection_module' instead of the
standard way to access gdk_set_allowed_backends. Calling it with 'x11'
makes sure that we always use the X11 backend, which is the only GDK
backend currently supported by Firefox.

This commit fixes https://github.com/GKFX/hide-ff-title-bar/issues/1.