### PR TITLE
Refactored python script

### DIFF
--- a/native/native.py
+++ b/native/native.py
@@ -125,7 +125,7 @@ class WhenToHideTitleBar(Enum):
             return cls.UNKNOWN
 
         for enumeration in cls:
-            if enumeration.vaue == value:
+            if enumeration.value == value:
                 return enumeration
 
         return cls.UNKNOWN

--- a/native/native.py
+++ b/native/native.py
@@ -157,12 +157,12 @@ def hide_title_bar():
 
     if when_to_hide_title_bar == WhenToHideTitleBar.ALWAYS:
         decoration = Gdk.WMDecoration.BORDER
-        reply = {'okay': 'true'}
+        reply = {'okay': True}
     elif when_to_hide_title_bar == WhenToHideTitleBar.MAX_ONLY:
         reply = {"knownFailure": "MAX_ONLY_UNSUPPORTED"}
     elif when_to_hide_title_bar == WhenToHideTitleBar.NEVER:
         decoration = Gdk.WMDecoration.ALL
-        reply = {'okay': 'true'}
+        reply = {'okay': True}
     else:
         reply = {'knownFailure': 'UNKNOWN_WHEN_TO_HIDE'}
 

--- a/native/native.py
+++ b/native/native.py
@@ -28,6 +28,7 @@ Window = namedtuple('Window', ('id', 'desktop', 'pid', 'machine', 'title'))
 
 
 def debug(msg):
+    """Writes a debug message."""
 
     with open('/tmp/hide-ff-title-bar.debug', 'a') as file:
         file.write('[{}] {}{}'.format(datetime.now(), msg, linesep))

--- a/native/native.py
+++ b/native/native.py
@@ -17,7 +17,9 @@ from subprocess import DEVNULL, PIPE, CalledProcessError, run
 from sys import stdin, stdout, stderr, exit
 
 from gi import require_version
+require_version('Gdk', '3.0')
 from gi.module import get_introspection_module
+get_introspection_module('Gdk').set_allowed_backends('x11')
 from gi.repository import Gdk, GdkX11
 
 
@@ -131,8 +133,6 @@ def hide_title_bar():
     except EmptyMessage:
         exit(0)
 
-    require_version('Gdk', '3.0')
-    get_introspection_module('Gdk').set_allowed_backends('x11')
     decoration = None
     when_to_hide_title_bar = WhenToHideTitleBar.from_message(received)
 

--- a/native/native.py
+++ b/native/native.py
@@ -9,7 +9,6 @@
 
 from collections import namedtuple
 from contextlib import suppress
-from datetime import datetime
 from enum import Enum
 from json import loads, dumps
 from os import linesep
@@ -25,13 +24,6 @@ from gi.repository import Gdk, GdkX11
 PROC_NAME = 'firefox'
 
 Window = namedtuple('Window', ('id', 'desktop', 'pid', 'machine', 'title'))
-
-
-def debug(msg):
-    """Writes a debug message."""
-
-    with open('/tmp/hide-ff-title-bar.debug', 'a') as file:
-        file.write('[{}] {}{}'.format(datetime.now(), msg, linesep))
 
 
 def window_from_string(string):
@@ -158,7 +150,6 @@ def hide_title_bar():
     """Main function to hide firefox's title bar."""
 
     received = get_message()
-    debug(str(received))
     require_version('Gdk', '3.0')
     get_introspection_module('Gdk').set_allowed_backends('x11')
     decoration = None
@@ -177,7 +168,6 @@ def hide_title_bar():
 
     if decoration is not None:
         for window in windows_by_procname(PROC_NAME):
-            debug('Decorating window: {}.'.format(window))
             decorate_window(window, decoration)
 
     send_message(reply)

--- a/native/native.py
+++ b/native/native.py
@@ -114,10 +114,6 @@ class WhenToHideTitleBar(Enum):
     NEVER = 'never'
     UNKNOWN = None
 
-    def __str__(self):
-        """Returns the enumeration's string value."""
-        return str(self.value)
-
     @classmethod
     def from_message(cls, msg):
         """Returns the respective enumeration
@@ -129,7 +125,7 @@ class WhenToHideTitleBar(Enum):
             return cls.UNKNOWN
 
         for enumeration in cls:
-            if str(enumeration) == value:
+            if enumeration.vaue == value:
                 return enumeration
 
         return cls.UNKNOWN


### PR DESCRIPTION
I took the liberty to completely refactor the python script `native.py`.  
I tested it with the dev-version of firefox.  

### Changes

- Broke down code into several separate functions (*divide and conquer*).
- Made use of some useful python structures like `namedtuple` and `Enum`.
- Made variable naming and indentation PEP8 compliant.

If you have any questions, please contact me.