### PR TITLE
re-trigger native script when new window is created

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,7 @@ function doNative(whenToHideTitleBar) {
         browser.storage.local.set({errorText: "UNKNOWN_FAILURE:" + response.unknownFailure});
       } else {
         browser.storage.local.set({errorText: "RESPONSE_NOT_UNDERSTOOD:" +
-          JSON.stringify(response));
+          JSON.stringify(response)});
         console.log(response);
       }
     },  failure => {
@@ -32,4 +32,10 @@ browser.storage.onChanged.addListener((changes, areaName) => {
   if ("whenToHideTitleBar" in changes) {
     doNative(changes.whenToHideTitleBar.newValue);
   }
+});
+
+browser.windows.onCreated.addListener((window) => {
+  browser.storage.local.get({ whenToHideTitleBar: "always" }).then(
+    prefs => doNative(prefs.whenToHideTitleBar)
+  );
 });


### PR DESCRIPTION
This fixes #5 by re-triggering the native script whenever a new window is opened. It does however not fix the problem, that *all* windows lose their decorations, not just regular browser windows.